### PR TITLE
Updated imports.

### DIFF
--- a/candies/cli/__init__.py
+++ b/candies/cli/__init__.py
@@ -1,0 +1,3 @@
+from candies.cli.cli import CLI, cli
+from candies.cli.command import Command
+from candies.cli.args import Arg, Opt, Flag, Typed

--- a/candies/cli/args/__init__.py
+++ b/candies/cli/args/__init__.py
@@ -1,0 +1,4 @@
+from candies.cli.args.arg import Arg
+from candies.cli.args.opt import Opt
+from candies.cli.args.flag import Flag
+from candies.cli.args.typed import Typed

--- a/candies/cli/parsers/__init__.py
+++ b/candies/cli/parsers/__init__.py
@@ -1,0 +1,2 @@
+from candies.cli.parsers.parser import Parser
+from candies.cli.parsers.standard import StandardParser


### PR DESCRIPTION
Closes #24.

Now it is possible to import as follows:
```python
from candies.cli import cli, CLI, Command, Arg, Opt, Flag, Typed
from candies.cli.parsers import Parser, StandardParser
```